### PR TITLE
chore: update fakeservice to v0.24.2

### DIFF
--- a/consul-ingress/app.hcl
+++ b/consul-ingress/app.hcl
@@ -39,7 +39,7 @@ container "ingress" {
 
 container "api" {
   image {
-    name = "nicholasjackson/fake-service:vm-v0.12.0"
+    name = "nicholasjackson/fake-service:vm-v0.24.2"
   }
 
   volume {
@@ -79,7 +79,7 @@ container "api" {
 
 container "web" {
   image {
-    name = "nicholasjackson/fake-service:vm-v0.12.0"
+    name = "nicholasjackson/fake-service:vm-v0.24.2"
   }
 
   volume {

--- a/consul-nomad-tracing/nomad_config/api.nomad
+++ b/consul-nomad-tracing/nomad_config/api.nomad
@@ -67,7 +67,7 @@ job "api" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.20.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/consul-nomad-tracing/nomad_config/currency.nomad
+++ b/consul-nomad-tracing/nomad_config/currency.nomad
@@ -70,7 +70,7 @@ job "currency" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.20.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/consul-nomad-tracing/nomad_config/payment.nomad
+++ b/consul-nomad-tracing/nomad_config/payment.nomad
@@ -73,7 +73,7 @@ job "payment" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.20.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
 
         port_map {
         }

--- a/consul-nomad-tracing/nomad_config/web.nomad
+++ b/consul-nomad-tracing/nomad_config/web.nomad
@@ -65,7 +65,7 @@ job "web" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.20.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/consul-terminating-gateways/database.hcl
+++ b/consul-terminating-gateways/database.hcl
@@ -45,7 +45,7 @@ container "database" {
   }
 
   image {
-    name = "nicholasjackson/fake-service:v0.14.1"
+    name = "nicholasjackson/fake-service:v0.24.2"
   }
 
   env {

--- a/consul-terminating-gateways/nomad_config/api.nomad
+++ b/consul-terminating-gateways/nomad_config/api.nomad
@@ -65,7 +65,7 @@ job "api" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.14.1"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
       
       env {

--- a/consul-terminating-gateways/nomad_config/api2.nomad
+++ b/consul-terminating-gateways/nomad_config/api2.nomad
@@ -65,7 +65,7 @@ job "api2" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.14.1"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
       
       env {

--- a/modules/consul-nomad/example/api.nomad
+++ b/modules/consul-nomad/example/api.nomad
@@ -67,7 +67,7 @@ job "api" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.22.9"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/modules/consul-nomad/example/waypoint.nomad
+++ b/modules/consul-nomad/example/waypoint.nomad
@@ -67,7 +67,7 @@ job "api" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.22.9"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/modules/consul-nomad/example/web.nomad
+++ b/modules/consul-nomad/example/web.nomad
@@ -61,7 +61,7 @@ job "web" {
       }
 
       config {
-        image = "nicholasjackson/fake-service:v0.22.9"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       resources {

--- a/not_working/consul-gateways/dc1.hcl
+++ b/not_working/consul-gateways/dc1.hcl
@@ -91,7 +91,7 @@ container_ingress "consul_http_dc1" {
 # Web application in DC1
 container "web_dc1" {
   image   {
-    name = "nicholasjackson/fake-service:vm-v0.7.11"
+    name = "nicholasjackson/fake-service:v0.24.2"
   }
 
   # Mount the service config for consul agent 

--- a/not_working/consul-gateways/dc2.hcl
+++ b/not_working/consul-gateways/dc2.hcl
@@ -91,7 +91,7 @@ container_ingress "consul_http_dc2" {
 # Web application in DC1
 container "api_dc2" {
   image   {
-    name = "nicholasjackson/fake-service:vm-v0.7.11"
+    name = "nicholasjackson/fake-service:vm-v0.24.2"
   }
 
   # Mount the service config for consul agent 

--- a/not_working/nomad-autoscaler/autoscale/api.hcl
+++ b/not_working/nomad-autoscaler/autoscale/api.hcl
@@ -52,7 +52,7 @@ job "api" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/job_dependency/payments.hcl
+++ b/not_working/nomad-autoscaler/job_dependency/payments.hcl
@@ -58,7 +58,7 @@ job "payments" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/stack/nomad_config/api.hcl
+++ b/not_working/nomad-autoscaler/stack/nomad_config/api.hcl
@@ -33,7 +33,7 @@ job "api" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/stack/nomad_config/currency.hcl
+++ b/not_working/nomad-autoscaler/stack/nomad_config/currency.hcl
@@ -52,7 +52,7 @@ EOH
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/stack/nomad_config/payments.hcl
+++ b/not_working/nomad-autoscaler/stack/nomad_config/payments.hcl
@@ -38,7 +38,7 @@ job "payments" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/stack/nomad_config/postgres.hcl
+++ b/not_working/nomad-autoscaler/stack/nomad_config/postgres.hcl
@@ -28,7 +28,7 @@ job "database" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/stack/nomad_config/web.hcl
+++ b/not_working/nomad-autoscaler/stack/nomad_config/web.hcl
@@ -38,7 +38,7 @@ job "web" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-autoscaler/task_dependency/payments.hcl
+++ b/not_working/nomad-autoscaler/task_dependency/payments.hcl
@@ -86,7 +86,7 @@ EOH
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-burst/1_test/cache.hcl
+++ b/not_working/nomad-burst/1_test/cache.hcl
@@ -61,7 +61,7 @@ job "cache" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/1_test/unicorn.hcl
+++ b/not_working/nomad-burst/1_test/unicorn.hcl
@@ -71,7 +71,7 @@ job "unicorn" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/2_burst/unicorn.hcl
+++ b/not_working/nomad-burst/2_burst/unicorn.hcl
@@ -90,7 +90,7 @@ job "unicorn" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/3_balance/queue.hcl
+++ b/not_working/nomad-burst/3_balance/queue.hcl
@@ -61,7 +61,7 @@ job "queue" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/nomad.hcl
+++ b/not_working/nomad-burst/nomad.hcl
@@ -28,7 +28,7 @@ nomad_cluster "onprem" {
   }
 
   image {
-      name = "nicholasjackson/fake-service:v0.9.0"
+      name = "nicholasjackson/fake-service:v0.24.2"
   }
 
   image {
@@ -75,7 +75,7 @@ nomad_cluster "cloud" {
   }
 
   image {
-      name = "nicholasjackson/fake-service:v0.9.0"
+      name = "nicholasjackson/fake-service:v0.24.2"
   }
 
   image {

--- a/not_working/nomad-burst/nomad_jobs/onprem/cache.hcl
+++ b/not_working/nomad-burst/nomad_jobs/onprem/cache.hcl
@@ -61,7 +61,7 @@ job "cache" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/nomad_jobs/onprem/database.hcl
+++ b/not_working/nomad-burst/nomad_jobs/onprem/database.hcl
@@ -94,7 +94,7 @@ EOH
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {

--- a/not_working/nomad-burst/nomad_jobs/onprem/nginx.hcl
+++ b/not_working/nomad-burst/nomad_jobs/onprem/nginx.hcl
@@ -71,7 +71,7 @@ job "nginx" {
       driver = "docker"
 
       config {
-        image = "nicholasjackson/fake-service:v0.9.0"
+        image = "nicholasjackson/fake-service:v0.24.2"
       }
 
       env {

--- a/not_working/nomad-burst/nomad_jobs/onprem/unicorn.hcl
+++ b/not_working/nomad-burst/nomad_jobs/onprem/unicorn.hcl
@@ -71,7 +71,7 @@ job "unicorn" {
             driver = "docker"
 
             config {
-                image = "nicholasjackson/fake-service:v0.9.0"
+                image = "nicholasjackson/fake-service:v0.24.2"
             }
 
             env {


### PR DESCRIPTION
Update fakeservice to the latest version with arm64 darwin support. This fixes several examples to run on m1 macs.