### PR TITLE
fix: remove stale refs in modules

### DIFF
--- a/consul-k8s-federated/variables.hcl
+++ b/consul-k8s-federated/variables.hcl
@@ -4,7 +4,7 @@ variable "consul_k8s_module" {
   local path for testing.
   EOT
 
-  default = "github.com/shipyard-run/blueprints?ref=891c937844bdbec673f5428b1a3c8bff4e207727/modules//kubernetes-consul"
+  default = "github.com/shipyard-run/blueprints/modules//kubernetes-consul"
   #default = "../modules/kubernetes-consul"
 }
 
@@ -14,7 +14,7 @@ variable "consul_docker_module" {
   local path for testing.
   EOT
 
-  default = "github.com/shipyard-run/blueprints?ref=e51d3ce48455b56edaf2a04e67182b846789daef/modules//consul-docker"
+  default = "github.com/shipyard-run/blueprints/modules//consul-docker"
 
   #default = "../modules/consul-docker"
 }

--- a/consul-terminating-gateways/main.hcl
+++ b/consul-terminating-gateways/main.hcl
@@ -23,7 +23,7 @@ network "database" {
 }
 
 module "nomad_consul" {
-  source = "github.com/shipyard-run/blueprints//modules/consul-nomad?ref=ffe7265d1cced3573a15b5c9412c7041d18a67fd"
+  source = "github.com/shipyard-run/blueprints//modules/consul-nomad"
   #source = "../modules/consul-nomad"
 }
 

--- a/modules/consul-nomad/README.md
+++ b/modules/consul-nomad/README.md
@@ -17,7 +17,7 @@ To use this blueprint you need to set the following variables:
 
 ```
 # Name of the network the cluster will be attached to (not created)
-variable "cn_networkd" {
+variable "cn_network" {
   default = "dc1"
 }
 ```

--- a/modules/consul-nomad/consul.hcl
+++ b/modules/consul-nomad/consul.hcl
@@ -7,5 +7,5 @@ variable "cd_consul_network" {
 }
 
 module "consul" {
-  source = "github.com/shipyard-run/blueprints?ref=5635f282cd28bcd2213494e558bf2151d10c7e9c/modules//consul-docker"
+  source = "github.com/shipyard-run/blueprints/modules//consul-docker"
 }

--- a/modules/kubernetes-consul/monitoring.hcl
+++ b/modules/kubernetes-consul/monitoring.hcl
@@ -1,7 +1,7 @@
 module "monitoring" {
   depends_on = ["helm.consul"]
   disabled   = var.consul_monitoring_enabled == false
-  source     = "github.com/shipyard-run/blueprints?ref=1c46f1127d5c60af738d8af5c65d8bca0e9f00ff/modules//kubernetes-monitoring"
+  source     = "github.com/shipyard-run/blueprints/modules//kubernetes-monitoring"
   #source = "../kubernetes-monitoring"
 }
 


### PR DESCRIPTION
I removed references in examples and modules as these appear to be going stale. The ref for consul-nomad is the mismatch I bumped into.

Additionally fixed a variable in the readme for consul-nomad.